### PR TITLE
Split lint and build action by package manager

### DIFF
--- a/.github/workflows/lint-and-build-npm.yml
+++ b/.github/workflows/lint-and-build-npm.yml
@@ -6,42 +6,42 @@ on:
       working-directory:
         required: false
         type: string
-        default: "."
+        default: '.'
       node-version:
         required: false
         type: string
-        default: "20.x"
+        default: '20.x'
       artifact-name:
         required: false
         type: string
-        description: "Name of artifact to use"
+        description: 'Name of artifact to use'
       artifact-path:
         required: false
         type: string
-        description: "Path to place artifact"
+        description: 'Path to place artifact'
       prepare-command:
         required: false
         type: string
-        description: "Command to run directly after checkout."
+        description: 'Command to run directly after checkout.'
       cleanup-command:
         required: false
         type: string
-        description: "Command to run after the workflow (even if failed)."
+        description: 'Command to run after the workflow (even if failed).'
       lint:
         type: boolean
-        description: "Run the lint step."
+        description: 'Run the lint step.'
         default: true
       format:
         type: boolean
-        description: "Run the format step."
+        description: 'Run the format step.'
         default: false
       test:
         type: boolean
-        description: "Run the test step."
+        description: 'Run the test step.'
         default: false
       build:
         type: boolean
-        description: "Run the build step."
+        description: 'Run the build step.'
         default: true
 
 jobs:

--- a/.github/workflows/lint-and-build-npm.yml
+++ b/.github/workflows/lint-and-build-npm.yml
@@ -1,0 +1,96 @@
+name: TypeScript Lint and Build with NPM
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        required: false
+        type: string
+        default: "."
+      node-version:
+        required: false
+        type: string
+        default: "20.x"
+      artifact-name:
+        required: false
+        type: string
+        description: "Name of artifact to use"
+      artifact-path:
+        required: false
+        type: string
+        description: "Path to place artifact"
+      prepare-command:
+        required: false
+        type: string
+        description: "Command to run directly after checkout."
+      cleanup-command:
+        required: false
+        type: string
+        description: "Command to run after the workflow (even if failed)."
+      lint:
+        type: boolean
+        description: "Run the lint step."
+        default: true
+      format:
+        type: boolean
+        description: "Run the format step."
+        default: false
+      test:
+        type: boolean
+        description: "Run the test step."
+        default: false
+      build:
+        type: boolean
+        description: "Run the build step."
+        default: true
+
+jobs:
+  npm-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
+        if: ${{ inputs.artifact-name != '' }}
+
+      - name: Prepare
+        run: ${{ inputs.prepare-command }}
+        if: ${{ inputs.prepare-command != '' }}
+
+      - name: Set Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: npm install
+
+      - name: Lint the project
+        working-directory: ${{ inputs.working-directory }}
+        run: npm run lint
+        if: ${{ inputs.lint }}
+
+      - name: Format the project
+        working-directory: ${{ inputs.working-directory }}
+        run: npm run format
+        if: ${{ inputs.format }}
+
+      - name: Test the project
+        working-directory: ${{ inputs.working-directory }}
+        run: npm run test
+        if: ${{ inputs.test }}
+
+      - name: Build the project
+        working-directory: ${{ inputs.working-directory }}
+        run: npm run build
+        if: ${{ inputs.build }}
+
+      - name: Cleanup
+        run: ${{ inputs.cleanup-command }}
+        if: ${{ inputs.cleanup-command != '' && always() }}

--- a/.github/workflows/lint-and-build-yarn.yml
+++ b/.github/workflows/lint-and-build-yarn.yml
@@ -1,30 +1,16 @@
-name: Build and Lint TypeScript Project
+name: TypeScript Lint and Build with Yarn
 
 on:
   workflow_call:
     inputs:
       working-directory:
         required: false
-        description: "The directory where the TypeScript project is located."
         type: string
         default: "."
       node-version:
         required: false
         type: string
-        description: "The node version required for the TypeScript project."
         default: "20.x"
-        # options:
-        #  - 22.x
-        #  - 20.x
-        #  - 18.x
-      package-manager:
-        required: false
-        type: string
-        description: "The package manager to use for the TypeScript project."
-        default: "npm"
-        # options:
-        #  - yarn
-        #  - npm
       artifact-name:
         required: false
         type: string
@@ -43,24 +29,23 @@ on:
         description: "Command to run after the workflow (even if failed)."
       lint:
         type: boolean
-        description: "Use the lint step."
+        description: "Run the lint step."
         default: true
       format:
         type: boolean
-        description: "Use the format step."
+        description: "Run the format step."
         default: false
       test:
         type: boolean
-        description: "Use the test step."
+        description: "Run the test step."
         default: false
       build:
         type: boolean
-        description: "Use the build step."
+        description: "Run the build step."
         default: true
 
 jobs:
-  build-and-lint-yarn:
-    if: ${{ inputs.package-manager == 'yarn' }}
+  yarn-steps:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -116,57 +101,6 @@ jobs:
           dir: ${{ inputs.working-directory }}
         if: ${{ inputs.build }}
 
-      - name: Cleanup 
-        run: ${{ inputs.cleanup-command }}
-        if: ${{ inputs.cleanup-command != '' && always() }}
-
-  build-and-lint-npm:
-    if: ${{ inputs.package-manager == 'npm' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.artifact-name }}
-          path: ${{ inputs.artifact-path }}
-        if: ${{ inputs.artifact-name != '' }}
-
-      - name: Prepare
-        run: ${{ inputs.prepare-command }}
-        if: ${{ inputs.prepare-command != '' }}
-
-      - name: Set Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-
-      - name: Install dependencies
-        working-directory: ${{ inputs.working-directory }}
-        run: npm install
-
-      - name: Lint the project
-        working-directory: ${{ inputs.working-directory }}
-        run: npm run lint
-        if: ${{ inputs.lint }}
-
-      - name: Format the project
-        working-directory: ${{ inputs.working-directory }}
-        run: npm run format
-        if: ${{ inputs.format }}
-
-      - name: Test the project
-        working-directory: ${{ inputs.working-directory }}
-        run: npm run test
-        if: ${{ inputs.test }}
-
-      - name: Build the project
-        working-directory: ${{ inputs.working-directory }}
-        run: npm run build
-        if: ${{ inputs.build }}
-
-      - name: Cleanup 
+      - name: Cleanup
         run: ${{ inputs.cleanup-command }}
         if: ${{ inputs.cleanup-command != '' && always() }}

--- a/.github/workflows/lint-and-build-yarn.yml
+++ b/.github/workflows/lint-and-build-yarn.yml
@@ -6,42 +6,42 @@ on:
       working-directory:
         required: false
         type: string
-        default: "."
+        default: '.'
       node-version:
         required: false
         type: string
-        default: "20.x"
+        default: '20.x'
       artifact-name:
         required: false
         type: string
-        description: "Name of artifact to use"
+        description: 'Name of artifact to use'
       artifact-path:
         required: false
         type: string
-        description: "Path to place artifact"
+        description: 'Path to place artifact'
       prepare-command:
         required: false
         type: string
-        description: "Command to run directly after checkout."
+        description: 'Command to run directly after checkout.'
       cleanup-command:
         required: false
         type: string
-        description: "Command to run after the workflow (even if failed)."
+        description: 'Command to run after the workflow (even if failed).'
       lint:
         type: boolean
-        description: "Run the lint step."
+        description: 'Run the lint step.'
         default: true
       format:
         type: boolean
-        description: "Run the format step."
+        description: 'Run the format step.'
         default: false
       test:
         type: boolean
-        description: "Run the test step."
+        description: 'Run the test step.'
         default: false
       build:
         type: boolean
-        description: "Run the build step."
+        description: 'Run the build step.'
         default: true
 
 jobs:

--- a/.github/workflows/typescript-lint-and-build.yml
+++ b/.github/workflows/typescript-lint-and-build.yml
@@ -1,5 +1,4 @@
-name: "Build and Lint TypeScript Project"
-description: "Reusable action to build and lint a TypeScript project."
+name: Build and Lint TypeScript Project
 
 on:
   workflow_call:

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,0 +1,17 @@
+name: "Validate Workflow Files"
+
+on:
+  push:
+    paths:
+      - ".github/workflows/*.yml"
+
+jobs:
+  validate-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '^1.23.0'
+      - run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+      - run: actionlint


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
In my opinion, this is a nicer solution that having a extra input to determine if its a yarn or npm project. Most notably, this will prevent there always being a skipped workflow action.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_