### PR TITLE
fix(npm-publish): sync GitHub and NPM version

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -45,7 +45,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish
-        run: npm publish --access public
+        run: npm version from-git --no-commit-hooks --no-git-tag-version && npm publish --access public
 
   publish-npm-lerna:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change does **not** update the version of a package in the `package.json` (unless the maintainer does this manually), but simply makes sure that before publishing, the version of the package is matched with that currently available in GitHub.

<!-- Provide a general summary of your changes in the title above. -->

# Description
Fixes that the NPM version is not naively fetched from `package.json` file, since versioning is in reality fully determined by GitHub actions.

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_
