### PR TITLE
fix: enable corepack

### DIFF
--- a/.github/workflows/lint-and-build-npm.yml
+++ b/.github/workflows/lint-and-build-npm.yml
@@ -72,6 +72,9 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install dependencies
         working-directory: ${{ inputs.working-directory }}
         run: npm install

--- a/.github/workflows/lint-and-build-yarn.yml
+++ b/.github/workflows/lint-and-build-yarn.yml
@@ -72,6 +72,9 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install dependencies
         uses: borales/actions-yarn@v5
         with:


### PR DESCRIPTION

# Description
Enable corepack to prevent issues with repositories that specify packageManagers. For example, currently, repositories using yarn@4.6.0 fail due to corepack not being enabled.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
