### PR TITLE
Allow login in to custom registry during Docker Build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,15 @@ on:
         required: true
         description: 'Comma-separated list of projects to build'
         type: string
+      docker-registry:
+        required: false
+        description: 'Docker registry for base images behind authentication'
+        type: string
+    secrets:
+      REGISTRY_USERNAME:
+        required: false
+      REGISTRY_PASSWORD:
+        required: false
 
 jobs:
   dockerize:
@@ -30,7 +39,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
 
-      - name: Build and push Docker image
+      - name: Login to Registry (Custom)
+        if: ${{ inputs.docker-registry != '' }}
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: ${{ inputs.docker-registry }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .

--- a/README.md
+++ b/README.md
@@ -61,9 +61,18 @@ jobs:
 
 ### Inputs
 
-| Input name | Description                                  | Required | Options | Default value |
-|------------|----------------------------------------------|----------|---------|---------------|
-| projects   | Comma-separated list of projects to release. | &#x2611; |         |               |
+| Input name      | Description                                            | Required | Options | Default value |
+|-----------------|--------------------------------------------------------|----------|---------|---------------|
+| projects        | Comma-separated list of projects to release.           | &#x2611; |         |               |
+| docker-registry | Docker registry for base images behind authentication. | &#x2610; |         |               |
+
+### Secrets
+
+| Secret name        | Secret value                               | 
+|--------------------|--------------------------------------------|
+| REGISTRY\_USERNAME | The username used for the custom registry. |
+| REGISTRY\_PASSWORD | The password used for the custom registry. |
+
 
 ## Docker release
 Workflow for building Docker images and releasing them. Can be used to push to GitHub and any other registry.


### PR DESCRIPTION


# Description
Since want to have private base images, we need to allow for auth before the docker build step.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
- New feature _(non-breaking change which adds functionality)_