### PR TITLE
Restore correct GHCR image path in docker-release workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -168,10 +168,11 @@ jobs:
             DOCKERFILE_PATH="${PROJECT_DIR}/Dockerfile"
           fi
 
+          IMAGE_NAME="${DOCKER_PATH_INPUT##*/}"
           {
             echo "context=${PROJECT_DIR}"
             echo "dockerfile=${DOCKERFILE_PATH}"
-            echo "ghcr_tags=ghcr.io/${DOCKER_PATH_INPUT}:latest,ghcr.io/${DOCKER_PATH_INPUT}:${VERSION_INPUT}"
+            echo "ghcr_tags=ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:latest,ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_INPUT}"
           } >> "${GITHUB_OUTPUT}"
 
           if [ -n "${REGISTRY_INPUT}" ]; then


### PR DESCRIPTION
## Summary

- The March 31 refactor ([4431492](https://github.com/GEWIS/actions/commit/4431492a)) dropped the old \"Extract Image Name\" step, which stripped the registry namespace prefix from \`docker-paths\` before building the GHCR tag.
- Without it, a \`docker-paths\` value like \`eou/pdf-compiler\` produces \`ghcr.io/eou/pdf-compiler\` — a path the \`GITHUB_TOKEN\` cannot push to (wrong owner).
- The original code took only the last segment after \`/\` and hardcoded \`gewis\` as the owner. This PR restores that behaviour but generalises it using \`$GITHUB_REPOSITORY_OWNER\` so it works for any org.

**Before:**
```bash
echo "ghcr_tags=ghcr.io/${DOCKER_PATH_INPUT}:latest,..."
# eou/pdf-compiler → ghcr.io/eou/pdf-compiler ✗
```

**After:**
```bash
IMAGE_NAME="${DOCKER_PATH_INPUT##*/}"
echo "ghcr_tags=ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:latest,..."
# eou/pdf-compiler → ghcr.io/gewis/pdf-compiler ✓
```

Custom-registry tags (`custom_tags`) are unchanged — they continue to use the full `docker-paths` value.

## Test plan

- [ ] Trigger a release on a repo that uses `github-registry: 'true'` and confirm the image lands at `ghcr.io/<org>/<image>` rather than `ghcr.io/<namespace>/<image>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)