### PR TITLE
Lowercase GHCR owner in docker-release image tag

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -169,10 +169,11 @@ jobs:
           fi
 
           IMAGE_NAME="${DOCKER_PATH_INPUT##*/}"
+          OWNER=$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
           {
             echo "context=${PROJECT_DIR}"
             echo "dockerfile=${DOCKERFILE_PATH}"
-            echo "ghcr_tags=ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:latest,ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_INPUT}"
+            echo "ghcr_tags=ghcr.io/${OWNER}/${IMAGE_NAME}:latest,ghcr.io/${OWNER}/${IMAGE_NAME}:${VERSION_INPUT}"
           } >> "${GITHUB_OUTPUT}"
 
           if [ -n "${REGISTRY_INPUT}" ]; then


### PR DESCRIPTION
## Summary

- Follow-up to #116.
- `$GITHUB_REPOSITORY_OWNER` preserves the original casing of the org name (e.g. `GEWIS`), but GHCR enforces all-lowercase repository names — resulting in `invalid tag "ghcr.io/GEWIS/pdf-compiler:latest": repository name must be lowercase`.
- Pipe the owner through `tr '[:upper:]' '[:lower:]'` before building the tag. Uses `printf` + `tr` rather than `${VAR,,}` for POSIX compatibility with the `docker:dind` (Alpine/sh) runner.

**Before:** `ghcr.io/GEWIS/pdf-compiler:latest` ✗

**After:** `ghcr.io/gewis/pdf-compiler:latest` ✓