### PR TITLE
Strip first segment of docker-path for GHCR tags

### DIFF
--- a/.github/workflows/docker-branch-release.yml
+++ b/.github/workflows/docker-branch-release.yml
@@ -10,7 +10,13 @@ on:
         type: string
       docker-paths:
         required: true
-        description: 'JSON array of Docker image paths corresponding to each project'
+        description: |
+          JSON array of Docker image paths matching projects, e.g. ["eou/plankapi"].
+          First segment should be the team name (eou, nc, pos, ...).
+          GHCR drops the team segment and prefixes the lowercased repo owner:
+          "eou/plankapi" -> ghcr.io/<owner>/plankapi.
+          Custom registry keeps the full path:
+          "eou/plankapi" -> <registry>/eou/plankapi.
         type: string
       docker-registry:
         required: false
@@ -192,10 +198,12 @@ jobs:
             DOCKERFILE_PATH="${PROJECT_DIR}/Dockerfile"
           fi
 
+          IMAGE_PATH="${DOCKER_PATH_INPUT#*/}"
+          OWNER=$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
           {
             echo "context=${PROJECT_DIR}"
             echo "dockerfile=${DOCKERFILE_PATH}"
-            echo "ghcr_tags=ghcr.io/${DOCKER_PATH_INPUT}:${BRANCH_TAG_INPUT}"
+            echo "ghcr_tags=ghcr.io/${OWNER}/${IMAGE_PATH}:${BRANCH_TAG_INPUT}"
           } >> "${GITHUB_OUTPUT}"
 
           if [ -n "${REGISTRY_INPUT}" ]; then

--- a/.github/workflows/docker-release-ghcr.yml
+++ b/.github/workflows/docker-release-ghcr.yml
@@ -26,7 +26,11 @@ on:
         type: string
       docker-paths:
         required: true
-        description: 'JSON array of Docker paths matching projects, e.g. ["gewis/app","gewis/api"]'
+        description: |
+          JSON array of Docker image paths matching projects, e.g. ["eou/plankapi"].
+          First segment should be the team name (eou, nc, pos, ...) and is dropped
+          on push; the lowercased repo owner is prefixed:
+          "eou/plankapi" -> ghcr.io/<owner>/plankapi.
         type: string
       build-contexts:
         required: false
@@ -154,10 +158,12 @@ jobs:
             DOCKERFILE_PATH="${PROJECT_DIR}/Dockerfile"
           fi
 
+          IMAGE_PATH="${DOCKER_PATH_INPUT#*/}"
+          OWNER=$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
           {
             echo "context=${PROJECT_DIR}"
             echo "dockerfile=${DOCKERFILE_PATH}"
-            echo "ghcr_tags=ghcr.io/${DOCKER_PATH_INPUT}:latest,ghcr.io/${DOCKER_PATH_INPUT}:${VERSION_INPUT}"
+            echo "ghcr_tags=ghcr.io/${OWNER}/${IMAGE_PATH}:latest,ghcr.io/${OWNER}/${IMAGE_PATH}:${VERSION_INPUT}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Build and push to GHCR

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -34,7 +34,13 @@ on:
         type: string
       docker-paths:
         required: true
-        description: 'JSON array of Docker image paths corresponding to each project'
+        description: |
+          JSON array of Docker image paths matching projects, e.g. ["eou/plankapi"].
+          First segment should be the team name (eou, nc, pos, ...).
+          GHCR drops the team segment and prefixes the lowercased repo owner:
+          "eou/plankapi" -> ghcr.io/<owner>/plankapi.
+          Custom registry keeps the full path:
+          "eou/plankapi" -> <registry>/eou/plankapi.
         type: string
       build-contexts:
         required: false
@@ -168,12 +174,12 @@ jobs:
             DOCKERFILE_PATH="${PROJECT_DIR}/Dockerfile"
           fi
 
-          IMAGE_NAME="${DOCKER_PATH_INPUT##*/}"
+          IMAGE_PATH="${DOCKER_PATH_INPUT#*/}"
           OWNER=$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
           {
             echo "context=${PROJECT_DIR}"
             echo "dockerfile=${DOCKERFILE_PATH}"
-            echo "ghcr_tags=ghcr.io/${OWNER}/${IMAGE_NAME}:latest,ghcr.io/${OWNER}/${IMAGE_NAME}:${VERSION_INPUT}"
+            echo "ghcr_tags=ghcr.io/${OWNER}/${IMAGE_PATH}:latest,ghcr.io/${OWNER}/${IMAGE_PATH}:${VERSION_INPUT}"
           } >> "${GITHUB_OUTPUT}"
 
           if [ -n "${REGISTRY_INPUT}" ]; then

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ jobs:
 | REGISTRY_USERNAME | The username used for the custom registry. |
 | REGISTRY_PASSWORD | The password used for the custom registry. |
 
+> [!NOTE]
+> The Docker release workflows below take `docker-paths` like `team/name` (e.g. `nc/aurora/core`). For GHCR pushes the team segment is dropped and the lowercased repo owner is prefixed (`nc/aurora/core` -> `ghcr.io/<owner>/aurora/core`). Custom registries receive the path as-is.
+
 ## Docker release
 
 Workflow for building Docker images and releasing them. Can be used to push to GitHub and any other registry.
@@ -103,7 +106,7 @@ jobs:
 | --------------- | ---------------------------------------------------------------------- | -------- | --------------- | ------------- |
 | projects        | JSON array of project contexts to release.                             | &#x2611; |                 |               |
 | version         | Version of the Docker release.                                         | &#x2611; |                 |               |
-| docker-paths    | JSON array of Docker image paths corresponding to each project.        | &#x2611; |                 |               |
+| docker-paths    | JSON array of image paths per project. See note above.                 | &#x2611; |                 |               |
 | docker-registry | The docker registry to push the build image to.                        | &#x2610; |                 |               |
 | github-registry | Whether to push the image to the GitHub registry.                      | &#x2610; | `true`, `false` | `false`       |
 | env-file        | Contents of the environment file to use during building.               | &#x2610; |                 |               |
@@ -129,7 +132,7 @@ jobs:
     uses: GEWIS/actions/.github/workflows/docker-release-ghcr.yml@v1
     with:
       projects: '["."]'
-      docker-paths: '["gewis/aurora/core"]'
+      docker-paths: '["nc/aurora/core"]'
       version: "4.0.40"
 ```
 
@@ -139,7 +142,7 @@ jobs:
 | ------------ | ---------------------------------------------------------------- | -------- | ------- | ------------- |
 | projects     | JSON array of project contexts to build, e.g. `["."]`.           | &#x2611; |         |               |
 | version      | Version tag for the Docker release.                              | &#x2611; |         |               |
-| docker-paths | JSON array of Docker paths matching projects.                    | &#x2611; |         |               |
+| docker-paths | JSON array of image paths per project. See note above.           | &#x2611; |         |               |
 | env-file     | Contents of the .env file to place in each project during build. | &#x2610; |         |               |
 | dockerfile   | Single Dockerfile path to use for every project.                 | &#x2610; |         |               |
 | dockerfiles  | JSON array of Dockerfile paths matching projects.                | &#x2610; |         |               |
@@ -156,7 +159,7 @@ jobs:
     uses: GEWIS/actions/.github/workflows/docker-branch-release.yml@v1
     with:
       projects: '["apps/dashboard","apps/point-of-sale"]'
-      docker-paths: '["gewis/sudosos-dashboard","gewis/sudosos-pos"]'
+      docker-paths: '["abc/sudosos-dashboard","abc/sudosos-pos"]'
       dockerfiles: '["apps/dashboard/Dockerfile","apps/point-of-sale/Dockerfile"]'
       docker-registry: "registry.example.org"
       env-file: ${{ vars.ENV_FILE_DEVELOPMENT }}
@@ -170,7 +173,7 @@ jobs:
 | Input name      | Description                                                         | Required | Options         | Default value |
 | --------------- | ------------------------------------------------------------------- | -------- | --------------- | ------------- |
 | projects        | JSON array of project contexts to release.                          | &#x2611; |                 |               |
-| docker-paths    | JSON array of Docker image paths corresponding to each project.     | &#x2611; |                 |               |
+| docker-paths    | JSON array of image paths per project. See note above.              | &#x2611; |                 |               |
 | docker-registry | The docker registry to push the build image to.                     | &#x2610; |                 |               |
 | github-registry | Whether to push the image to the GitHub registry.                   | &#x2610; | `true`, `false` | `false`       |
 | env-file        | Contents of the environment file to use during building.            | &#x2610; |                 |               |


### PR DESCRIPTION
GHCR tagging now strips the first segment of `docker-path` and prefixes the lowercased repo owner. So `docker-paths: ["nc/aurora/core"]` on GEWIS pushes to `ghcr.io/gewis/aurora/core`.

The three release workflows (`docker-release`, `docker-release-ghcr`, `docker-branch-release`) were doing different things here, so this lines them up. Custom-registry tags still use the raw `docker-path`.

## Test plan

- [ ] CI passes (`actionlint`, `zizmor`)
- [ ] Trigger a test release from a consumer repo with a multi-segment `docker-path` and confirm the GHCR tag resolves to `ghcr.io/<owner>/<rest-of-path>`