### PR TITLE
Add jfrog/boost@v0 as initial step in reusable workflows

### DIFF
--- a/.github/workflows/docker-branch-release.yml
+++ b/.github/workflows/docker-branch-release.yml
@@ -58,6 +58,8 @@ jobs:
       matrix: ${{ steps.prepare.outputs.matrix }}
       branch-tag: ${{ steps.prepare.outputs.branch-tag }}
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Prepare release matrix
         id: prepare
         env:
@@ -128,6 +130,8 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,6 +44,8 @@ jobs:
     outputs:
       matrix: ${{ steps.prepare.outputs.matrix }}
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Prepare build matrix
         id: prepare
         env:
@@ -84,6 +86,8 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
 
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/docker-release-ghcr.yml
+++ b/.github/workflows/docker-release-ghcr.yml
@@ -47,6 +47,8 @@ jobs:
     outputs:
       matrix: ${{ steps.prepare.outputs.matrix }}
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Prepare release matrix
         id: prepare
         env:
@@ -98,6 +100,8 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
 
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -61,6 +61,8 @@ jobs:
     outputs:
       matrix: ${{ steps.prepare.outputs.matrix }}
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Prepare release matrix
         id: prepare
         env:
@@ -112,6 +114,8 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
 
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/lint-and-build-go.yml
+++ b/.github/workflows/lint-and-build-go.yml
@@ -1,1 +1,101 @@
-# reusable workflowname: Golang Lint and Buildon:  workflow_call:    inputs:      working-directory:        required: false        type: string        default: '.'      go-version:        required: false        type: string        default: '^1.24.0'      artifact-name:        required: false        type: string        description: 'Name of artifact to use'      artifact-path:        required: false        type: string        description: 'Path to place artifact'      prepare-command:        required: false        type: string        description: 'Command to run directly after checkout.'      cleanup-command:        required: false        type: string        description: 'Command to run after the workflow (even if failed).'      format:        type: boolean        description: 'Run go fmt'        default: true      lint:        type: boolean        description: 'Run go vet'        default: true      test:        type: boolean        description: 'Run go test'        default: true      build:        type: boolean        description: 'Build the binary'        default: truejobs:  go-steps:    runs-on: ubuntu-latest    steps:      - name: Checkout        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd        with:          persist-credentials: false      - name: Artifact        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c        with:          name: ${{ inputs.artifact-name }}          path: ${{ inputs.artifact-path }}        if: ${{ inputs.artifact-name != '' }}      - name: Prepare        env:          PREPARE_CMD: ${{ inputs.prepare-command }}        if: ${{ inputs.prepare-command != '' }}        run: bash -c "$PREPARE_CMD"      - name: Setup Go        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c        with:          go-version: ${{ inputs.go-version }}      - name: go fmt        working-directory: ${{ inputs.working-directory }}        run: go fmt ./...        if: ${{ inputs.format }}      - name: go vet        working-directory: ${{ inputs.working-directory }}        run: go vet ./...        if: ${{ inputs.lint }}      - name: go test        working-directory: ${{ inputs.working-directory }}        run: go test ./...        if: ${{ inputs.test }}      - name: go build        working-directory: ${{ inputs.working-directory }}        run: go build ./...        if: ${{ inputs.build }}      - name: Cleanup        env:          CLEANUP_CMD: ${{ inputs.cleanup-command }}        run: bash -c "$CLEANUP_CMD"        if: ${{ inputs.cleanup-command != '' && always() }}
+# reusable workflow
+name: Golang Lint and Build
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+      go-version:
+        required: false
+        type: string
+        default: '^1.24.0'
+      artifact-name:
+        required: false
+        type: string
+        description: 'Name of artifact to use'
+      artifact-path:
+        required: false
+        type: string
+        description: 'Path to place artifact'
+      prepare-command:
+        required: false
+        type: string
+        description: 'Command to run directly after checkout.'
+      cleanup-command:
+        required: false
+        type: string
+        description: 'Command to run after the workflow (even if failed).'
+      format:
+        type: boolean
+        description: 'Run go fmt'
+        default: true
+      lint:
+        type: boolean
+        description: 'Run go vet'
+        default: true
+      test:
+        type: boolean
+        description: 'Run go test'
+        default: true
+      build:
+        type: boolean
+        description: 'Build the binary'
+        default: true
+
+jobs:
+  go-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
+        if: ${{ inputs.artifact-name != '' }}
+
+      - name: Prepare
+        env:
+          PREPARE_CMD: ${{ inputs.prepare-command }}
+        if: ${{ inputs.prepare-command != '' }}
+        run: bash -c "$PREPARE_CMD"
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: go fmt
+        working-directory: ${{ inputs.working-directory }}
+        run: go fmt ./...
+        if: ${{ inputs.format }}
+
+      - name: go vet
+        working-directory: ${{ inputs.working-directory }}
+        run: go vet ./...
+        if: ${{ inputs.lint }}
+
+      - name: go test
+        working-directory: ${{ inputs.working-directory }}
+        run: go test ./...
+        if: ${{ inputs.test }}
+
+      - name: go build
+        working-directory: ${{ inputs.working-directory }}
+        run: go build ./...
+        if: ${{ inputs.build }}
+
+      - name: Cleanup
+        env:
+          CLEANUP_CMD: ${{ inputs.cleanup-command }}
+        run: bash -c "$CLEANUP_CMD"
+        if: ${{ inputs.cleanup-command != '' && always() }}

--- a/.github/workflows/lint-and-build-npm.yml
+++ b/.github/workflows/lint-and-build-npm.yml
@@ -49,6 +49,8 @@ jobs:
   npm-steps:
     runs-on: ubuntu-latest
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/lint-and-build-yarn.yml
+++ b/.github/workflows/lint-and-build-yarn.yml
@@ -49,6 +49,8 @@ jobs:
   yarn-steps:
     runs-on: ubuntu-latest
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -35,6 +35,8 @@ jobs:
       packages: write
       id-token: write
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -64,6 +66,8 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -37,6 +37,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Check for existing PR
         id: check-pr
         env:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -28,6 +28,8 @@ jobs:
     outputs:
       next-version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
+      - uses: jfrog/boost@96489172747f2a338464b1e747a0496717b535d8
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:


### PR DESCRIPTION
## Summary
- Adds `- uses: jfrog/boost@v0` as the first step (before checkout) in every job across the 10 reusable workflows in `.github/workflows/`.
- Normalizes `lint-and-build-go.yml` from CR-only line endings to LF. That file was the only one in the repo with classic-Mac line endings, which made it render as a single line in most viewers.

Not touched:
- `examples/*.yml` and `.github/workflows/self-versioning.yml` only delegate via `uses:`, so there's no `steps:` block to insert into. They pick up the new step through the reusable workflows they call.
- `.github/workflows/validate-workflows.yml` isn't a reusable workflow (push-triggered). Left it alone -- shout if you want it added there too.

## Test plan
- [ ] `validate-workflows` (actionlint + zizmor) passes on this PR
- [ ] downstream callers still resolve and run the reusable workflows