### PR TITLE
feat: dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Fetch dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@99a08bf4ec2793c7452e1d96f462b3092dcf8eca # v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,80 @@
+# reusable workflow
+name: Dependabot Auto Approve and Merge
+
+on:
+  workflow_call:
+    inputs:
+      auto-approve:
+        type: boolean
+        required: false
+        default: true
+        description: 'Automatically approve the pull request'
+      auto-merge:
+        type: boolean
+        required: false
+        default: true
+        description: 'Enable GitHub auto-merge on the pull request'
+      actor:
+        type: string
+        required: false
+        default: 'dependabot[bot]'
+        description: 'GitHub login of the bot allowed to trigger this workflow'
+      update-types:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional comma-separated list of allowed update types. Possible values: version-update:semver-patch, version-update:semver-minor, version-update:semver-major. Empty allows any type.'
+      merge-method:
+        type: string
+        required: false
+        default: 'merge'
+        description: 'Merge method to enable for auto-merge. One of `merge`, `squash`, or `rebase`.'
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ (inputs.auto-approve || inputs.auto-merge) && github.event.pull_request.user.login == inputs.actor }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@99a08bf4ec2793c7452e1d96f462b3092dcf8eca # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify update type allowlist
+        id: allowlist
+        continue-on-error: true
+        env:
+          UPDATE_TYPES: ${{ inputs.update-types }}
+          ACTUAL_UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: |
+          if [ -z "${UPDATE_TYPES}" ]; then
+            exit 0
+          fi
+          # shellcheck disable=SC2206
+          ALLOWED_TYPES=( ${UPDATE_TYPES//,/ } )
+          for type in "${ALLOWED_TYPES[@]}"; do
+            if [ "${type}" = "${ACTUAL_UPDATE_TYPE}" ]; then
+              exit 0
+            fi
+          done
+          echo "Blocked: update type '${ACTUAL_UPDATE_TYPE}' is not in allowlist '${UPDATE_TYPES}'"
+          exit 1
+
+      - name: Approve pull request
+        if: ${{ inputs.auto-approve && steps.allowlist.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review --approve "${PR_URL}"
+
+      - name: Enable auto-merge
+        if: ${{ inputs.auto-merge && steps.allowlist.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          MERGE_METHOD: ${{ inputs.merge-method }}
+        run: gh pr merge --auto "--${MERGE_METHOD}" "${PR_URL}"

--- a/.github/workflows/self-dependabot.yml
+++ b/.github/workflows/self-dependabot.yml
@@ -1,0 +1,21 @@
+name: Dependabot Auto Approve and Merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependabot:
+    uses: ./.github/workflows/dependabot-auto-merge.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      auto-approve: true
+      auto-merge: true
+      merge-method: 'squash'

--- a/README.md
+++ b/README.md
@@ -271,6 +271,43 @@ jobs:
 | body        | Body for the release PR.                 | &#x2610; |                 | See workflow  |
 | draft       | Whether the release PR should be a draft | &#x2610; | `true`, `false` | `true`        |
 
+## Dependabot auto approve and merge
+
+Reusable workflow for automatically approving Dependabot pull requests and enabling GitHub auto-merge.
+Both behaviours are independent and can be toggled separately. The workflow uses
+[`dependabot/fetch-metadata`](https://github.com/dependabot/fetch-metadata) to gate on the
+update type and dependency name when configured.
+
+```yaml
+jobs:
+  dependabot:
+    uses: GEWIS/actions/.github/workflows/dependabot-auto-merge.yml@v1
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      auto-approve: true
+      auto-merge: true
+      merge-method: "squash"
+      # Optional: only auto-merge patch and minor updates
+      update-types: "version-update:semver-patch,version-update:semver-minor"
+```
+
+### Inputs
+
+| Input name        | Description                                                                                          | Required | Options                                            | Default value      |
+| ----------------- | ---------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------------- | ------------------ |
+| auto-approve      | Automatically approve the pull request.                                                              | &#x2612; | `true`, `false`                                    | `true`             |
+| auto-merge        | Enable GitHub auto-merge on the pull request.                                                         | &#x2612; | `true`, `false`                                    | `true`             |
+| actor             | GitHub login of the bot allowed to trigger this workflow.                                            | &#x2610; |                                                    | `dependabot[bot]`  |
+| update-types      | Optional comma-separated list of allowed update types. Empty allows any type.                        | &#x2610; | `version-update:semver-patch`, `version-update:semver-minor`, `version-update:semver-major` |                    |
+| merge-method      | Merge method to enable for auto-merge.                                                               | &#x2610; | `merge`, `squash`, `rebase`                        | `merge`            |
+
+> [!NOTE]
+> Branch protection must allow auto-merge for the target branch, and any required status checks
+> must pass before the PR is merged. See
+> [Automatically merging a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request).
+
 ## Examples
 
 Example workflows for building, versioning and releasing a project can be found in the [examples](./examples) directory.

--- a/examples/dependabot-auto-merge.yml
+++ b/examples/dependabot-auto-merge.yml
@@ -1,0 +1,26 @@
+# This example is self-validating inside the GEWIS/actions repository.
+# Downstream repositories should replace the local reusable-workflow path
+# with GEWIS/actions/.github/workflows/dependabot-auto-merge.yml@v1.
+name: Dependabot Auto Approve and Merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependabot:
+    uses: ./.github/workflows/dependabot-auto-merge.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      # Approve and enable auto-merge for any dependabot PR.
+      auto-approve: true
+      auto-merge: true
+      # squash is a sensible default for dependabot PRs; change as needed.
+      merge-method: 'squash'


### PR DESCRIPTION
# Description

 Adds a caller workflow `.github/workflows/self-dependabot.yml` that invokes the existing reusable `dependabot-auto-merge.yml` for pull requests on main, enabling Dependabot PRs in this repository to be auto-approved and squash-merged.

# Types of changes

- Feature
 - CI/CD
