### PR TITLE
Scope Docker layer cache per matrix project

### DIFF
--- a/.github/workflows/docker-branch-release.yml
+++ b/.github/workflows/docker-branch-release.yml
@@ -219,8 +219,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.resolve.outputs.ghcr_tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.project }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.project }}
           build-args: ${{ inputs.build-args }}
           build-contexts: ${{ inputs.build-contexts }}
 
@@ -241,7 +241,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.resolve.outputs.custom_tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.project }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.project }}
           build-args: ${{ inputs.build-args }}
           build-contexts: ${{ inputs.build-contexts }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -145,7 +145,7 @@ jobs:
           file: ${{ steps.resolve.outputs.dockerfile }}
           platforms: linux/amd64
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.project }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.project }}
           build-args: ${{ inputs.build-args }}
           build-contexts: ${{ inputs.build-contexts }}

--- a/.github/workflows/docker-release-ghcr.yml
+++ b/.github/workflows/docker-release-ghcr.yml
@@ -174,7 +174,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.resolve.outputs.ghcr_tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.project }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.project }}
           build-args: ${{ inputs.build-args }}
           build-contexts: ${{ inputs.build-contexts }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -195,8 +195,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.resolve.outputs.ghcr_tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.project }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.project }}
           build-args: ${{ inputs.build-args }}
           build-contexts: ${{ inputs.build-contexts }}
 
@@ -217,7 +217,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.resolve.outputs.custom_tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.project }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.project }}
           build-args: ${{ inputs.build-args }}
           build-contexts: ${{ inputs.build-contexts }}


### PR DESCRIPTION
## Summary

All four Docker build/release workflows (`docker-build.yml`, `docker-release-ghcr.yml`, `docker-branch-release.yml`, `docker-release.yml`) run a matrix over several independent project directories in a single caller (e.g. `frontend`, `frontend/nginx`, `backend`), but every `cache-from`/`cache-to` step uses a bare `type=gha` with no `scope`. `docker/build-push-action`'s GHA cache backend keys entries by scope and falls back to one shared scope for the whole run when none is set, so BuildKit can import a cache layer that was actually built for a different Dockerfile/context in the same matrix as long as the instruction signature happens to match. It ends up serving stale output instead of invalidating it.

## How this surfaced

I was debugging why radio.gewis.nl (GEWIS/intro-radio) still showed an unfixed animation after the fix had merged and a new image had been published. The frontend container's own index.html still referenced a CSS bundle that predated the fix, while the correct build output for that same commit sat in the same image under a different, unreferenced filename. Two different builds' artifacts had ended up mixed into one image. intro-radio's release workflow calls docker-release-ghcr.yml in a three-way matrix (frontend, frontend/nginx, backend), none of them scoped, which matches this failure mode exactly.

## Fix

Adds `scope=${{ matrix.project }}` to every `cache-from`/`cache-to` pair in all four workflows, so each project's cache stays isolated from every other project sharing the same run. This doesn't change behavior for callers -- `matrix.project` is already the per-leg project path used elsewhere in each of these workflows, so no public inputs are touched.

## Testing

- `actionlint` and a plain YAML parse pass on all four modified files.
- I didn't reproduce the cache collision itself in CI (that needs a real matrix run against an already-populated cache to trigger). But the mechanism matches the intro-radio symptom precisely, and scoping cache per matrix leg is the standard fix for this `docker/build-push-action` + GHA-cache + matrix combination.
