### PR TITLE
Add opt-in coverage reporting to the yarn and go lint-and-build workflows

### DIFF
--- a/.github/workflows/lint-and-build-go.yml
+++ b/.github/workflows/lint-and-build-go.yml
@@ -1,1 +1,129 @@
-# reusable workflowname: Golang Lint and Buildon:  workflow_call:    inputs:      working-directory:        required: false        type: string        default: '.'      go-version:        required: false        type: string        default: '^1.24.0'      artifact-name:        required: false        type: string        description: 'Name of artifact to use'      artifact-path:        required: false        type: string        description: 'Path to place artifact'      prepare-command:        required: false        type: string        description: 'Command to run directly after checkout.'      cleanup-command:        required: false        type: string        description: 'Command to run after the workflow (even if failed).'      format:        type: boolean        description: 'Run go fmt'        default: true      lint:        type: boolean        description: 'Run go vet'        default: true      test:        type: boolean        description: 'Run go test'        default: true      build:        type: boolean        description: 'Build the binary'        default: truejobs:  go-steps:    runs-on: ubuntu-latest    steps:      - name: Checkout        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1        with:          persist-credentials: false      - name: Artifact        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c        with:          name: ${{ inputs.artifact-name }}          path: ${{ inputs.artifact-path }}        if: ${{ inputs.artifact-name != '' }}      - name: Prepare        env:          PREPARE_CMD: ${{ inputs.prepare-command }}        if: ${{ inputs.prepare-command != '' }}        run: bash -c "$PREPARE_CMD"      - name: Setup Go        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e        with:          go-version: ${{ inputs.go-version }}      - name: go fmt        working-directory: ${{ inputs.working-directory }}        run: go fmt ./...        if: ${{ inputs.format }}      - name: go vet        working-directory: ${{ inputs.working-directory }}        run: go vet ./...        if: ${{ inputs.lint }}      - name: go test        working-directory: ${{ inputs.working-directory }}        run: go test ./...        if: ${{ inputs.test }}      - name: go build        working-directory: ${{ inputs.working-directory }}        run: go build ./...        if: ${{ inputs.build }}      - name: Cleanup        env:          CLEANUP_CMD: ${{ inputs.cleanup-command }}        run: bash -c "$CLEANUP_CMD"        if: ${{ inputs.cleanup-command != '' && always() }}
+# reusable workflow
+name: Golang Lint and Build
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+      go-version:
+        required: false
+        type: string
+        default: '^1.24.0'
+      artifact-name:
+        required: false
+        type: string
+        description: 'Name of artifact to use'
+      artifact-path:
+        required: false
+        type: string
+        description: 'Path to place artifact'
+      prepare-command:
+        required: false
+        type: string
+        description: 'Command to run directly after checkout.'
+      cleanup-command:
+        required: false
+        type: string
+        description: 'Command to run after the workflow (even if failed).'
+      format:
+        type: boolean
+        description: 'Run go fmt'
+        default: true
+      lint:
+        type: boolean
+        description: 'Run go vet'
+        default: true
+      test:
+        type: boolean
+        description: 'Run go test'
+        default: true
+      coverage:
+        type: boolean
+        description: 'Run go test with coverage and post a report comment on the pull request. Requires "test" to also be true, and requires the caller to grant this job pull-requests: write.'
+        default: false
+      build:
+        type: boolean
+        description: 'Build the binary'
+        default: true
+
+jobs:
+  go-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
+        if: ${{ inputs.artifact-name != '' }}
+
+      - name: Prepare
+        env:
+          PREPARE_CMD: ${{ inputs.prepare-command }}
+        if: ${{ inputs.prepare-command != '' }}
+        run: bash -c "$PREPARE_CMD"
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: go fmt
+        working-directory: ${{ inputs.working-directory }}
+        run: go fmt ./...
+        if: ${{ inputs.format }}
+
+      - name: go vet
+        working-directory: ${{ inputs.working-directory }}
+        run: go vet ./...
+        if: ${{ inputs.lint }}
+
+      - name: go test
+        working-directory: ${{ inputs.working-directory }}
+        run: go test ./...
+        if: ${{ inputs.test && !inputs.coverage }}
+
+      - name: go test with coverage
+        working-directory: ${{ inputs.working-directory }}
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+        if: ${{ inputs.test && inputs.coverage }}
+
+      - name: Build coverage report
+        working-directory: ${{ inputs.working-directory }}
+        if: ${{ inputs.test && inputs.coverage && github.event_name == 'pull_request' }}
+        run: |
+          {
+            echo '## Go test coverage'
+            echo '```'
+            go tool cover -func=coverage.out
+            echo '```'
+          } > coverage-report.md
+
+      - name: Report coverage on the pull request
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        if: ${{ inputs.test && inputs.coverage && github.event_name == 'pull_request' }}
+        with:
+          header: go-test-coverage
+          path: ${{ inputs.working-directory }}/coverage-report.md
+
+      - name: go build
+        working-directory: ${{ inputs.working-directory }}
+        run: go build ./...
+        if: ${{ inputs.build }}
+
+      - name: Cleanup
+        env:
+          CLEANUP_CMD: ${{ inputs.cleanup-command }}
+        run: bash -c "$CLEANUP_CMD"
+        if: ${{ inputs.cleanup-command != '' && always() }}

--- a/.github/workflows/lint-and-build-yarn.yml
+++ b/.github/workflows/lint-and-build-yarn.yml
@@ -40,6 +40,10 @@ on:
         type: boolean
         description: 'Run the test step.'
         default: false
+      coverage:
+        type: boolean
+        description: 'Run the test step with coverage and post a report comment on the pull request. Requires "test" to also be true, and requires the caller to grant this job pull-requests: write.'
+        default: false
       build:
         type: boolean
         description: 'Run the build step.'
@@ -48,6 +52,9 @@ on:
 jobs:
   yarn-steps:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -94,7 +101,22 @@ jobs:
       - name: Test the project
         run: yarn test
         working-directory: ${{ inputs.working-directory }}
-        if: ${{ inputs.test }}
+        if: ${{ inputs.test && !inputs.coverage }}
+
+      - name: Test the project with coverage
+        run: yarn test --coverage
+        working-directory: ${{ inputs.working-directory }}
+        if: ${{ inputs.test && inputs.coverage }}
+
+      # Requires @vitest/coverage-v8 (or another coverage provider) installed
+      # in the caller's project, and `coverage.reporter` in its Vitest config
+      # to include 'json-summary' -- this action reads
+      # coverage/coverage-summary.json, which only that reporter produces.
+      - name: Report coverage on the pull request
+        uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2.12.2
+        if: ${{ inputs.test && inputs.coverage && github.event_name == 'pull_request' }}
+        with:
+          working-directory: ${{ inputs.working-directory }}
 
       - name: Build the project
         run: yarn build


### PR DESCRIPTION
## Summary

Adds an opt-in `coverage` input to both `lint-and-build-yarn.yml` and `lint-and-build-go.yml`. When `coverage: true` (and `test: true`), the test step runs with coverage enabled and posts a report as a PR comment:

- **Yarn**: runs `yarn test --coverage`, then `davelosert/vitest-coverage-report-action` reads `coverage/coverage-summary.json`. This needs the caller's project to already have `@vitest/coverage-v8` (or another provider) installed and a `json-summary` reporter configured in its Vitest config -- coverage tooling is a project-level dependency, not something this workflow should own.
- **Go**: runs `go test -coverprofile=coverage.out -covermode=atomic ./...`, then formats `go tool cover -func` output into a markdown comment via `marocchino/sticky-pull-request-comment`.

Both jobs now declare `permissions: pull-requests: write` at the job level for the comment step. Existing callers aren't affected: `coverage` defaults to `false`, and the added permission has nothing to act on unless a caller opts in.

## Incidental fix

`lint-and-build-go.yml` was the only workflow in this repo using bare-CR line endings -- checked the git blob directly, so this isn't a local checkout artifact. Every diff or editor view of the file rendered as one solid line because of it. Normalized to LF while already in there; no other content changes.

## Testing

`actionlint` and `zizmor` both pass clean on both files (0 findings beyond the pre-existing suppressions). I can't exercise the actual PR-comment steps from here since they need a real pull_request event to fire against -- a companion PR to GEWIS/intro-radio wires both workflows up with `coverage: true` and will be the first real run. Will link it here once it's open.
